### PR TITLE
i1952: Add models for expectations

### DIFF
--- a/src/main/kotlin/org/vaccineimpact/api/models/Country.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/Country.kt
@@ -1,0 +1,7 @@
+package org.vaccineimpact.api.models
+
+import java.beans.ConstructorProperties
+
+data class Country
+@ConstructorProperties("id", "name")
+constructor(val id: String, val name: String)

--- a/src/main/kotlin/org/vaccineimpact/api/models/Expectations.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/Expectations.kt
@@ -1,0 +1,14 @@
+package org.vaccineimpact.api.models
+
+data class Expectations(
+        val years: IntRange,
+        val ages: IntRange,
+        val cohorts: CohortRestriction,
+        val countries: List<Country>,
+        val outcomes: List<String>
+)
+
+data class CohortRestriction(
+        val minimumBirthYear: Short? = null,
+        val maximumBirthYear: Short? = null
+)


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-1952

These are not actually models that will (at least for now) exposed outside the API - they are just for internally modelling things. I'm not sure whether they belong in this submodule?