### PR TITLE
I2390 - add data models for new endpoint

### DIFF
--- a/src/main/kotlin/org/vaccineimpact/api/models/BurdenEstimate.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/BurdenEstimate.kt
@@ -3,15 +3,28 @@ package org.vaccineimpact.api.models
 import org.vaccineimpact.api.models.helpers.FlexibleColumns
 import org.vaccineimpact.api.models.helpers.FlexibleProperty
 import java.beans.ConstructorProperties
-import java.math.BigDecimal
 
-data class AggregatedBurdenEstimate
-@ConstructorProperties("year", "age", "value")
+data class DataPoint
 constructor(
         val x: Short,
-        val age: Short,
         val y: Float
 )
+
+interface ChartSerializable {
+    fun toDataPoint(): DataPoint
+}
+
+data class DisAggregatedBurdenEstimate
+@ConstructorProperties("year", "age", "value")
+constructor(
+        val year: Short,
+        val age: Short,
+        val value: Float
+): ChartSerializable
+{
+
+    override fun toDataPoint(): DataPoint = DataPoint(this.year, this.value)
+}
 
 interface BurdenEstimateRow
 
@@ -25,7 +38,7 @@ data class BurdenEstimate(
         val cohortSize: Float,
         @FlexibleProperty
         val outcomes: Map<String, Float?>
-): BurdenEstimateRow
+) : BurdenEstimateRow
 
 @FlexibleColumns
 data class StochasticBurdenEstimate(
@@ -38,7 +51,7 @@ data class StochasticBurdenEstimate(
         val cohortSize: Float,
         @FlexibleProperty
         val outcomes: Map<String, Float?>
-): BurdenEstimateRow
+) : BurdenEstimateRow
 
 data class BurdenEstimateWithRunId(
         val disease: String,
@@ -57,6 +70,7 @@ data class BurdenEstimateWithRunId(
             estimate.year, estimate.age, estimate.country, estimate.countryName,
             estimate.cohortSize, estimate.outcomes
     )
+
     constructor(estimate: StochasticBurdenEstimate) : this(
             estimate.disease, estimate.runId,
             estimate.year, estimate.age, estimate.country, estimate.countryName,

--- a/src/main/kotlin/org/vaccineimpact/api/models/BurdenEstimate.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/BurdenEstimate.kt
@@ -2,11 +2,14 @@ package org.vaccineimpact.api.models
 
 import org.vaccineimpact.api.models.helpers.FlexibleColumns
 import org.vaccineimpact.api.models.helpers.FlexibleProperty
+import java.beans.ConstructorProperties
 import java.math.BigDecimal
 
-data class AggregatedBurdenEstimate(
-        val year: Int,
-        val age: Int,
+data class AggregatedBurdenEstimate
+@ConstructorProperties("year", "age", "value")
+constructor(
+        val year: Short,
+        val age: Short,
         val value: Float
 )
 

--- a/src/main/kotlin/org/vaccineimpact/api/models/BurdenEstimate.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/BurdenEstimate.kt
@@ -4,28 +4,6 @@ import org.vaccineimpact.api.models.helpers.FlexibleColumns
 import org.vaccineimpact.api.models.helpers.FlexibleProperty
 import java.beans.ConstructorProperties
 
-data class DataPoint
-constructor(
-        val x: Short,
-        val y: Float
-)
-
-interface ChartSerializable {
-    fun toDataPoint(): DataPoint
-}
-
-data class DisAggregatedBurdenEstimate
-@ConstructorProperties("year", "age", "value")
-constructor(
-        val year: Short,
-        val age: Short,
-        val value: Float
-): ChartSerializable
-{
-
-    override fun toDataPoint(): DataPoint = DataPoint(this.year, this.value)
-}
-
 interface BurdenEstimateRow
 
 @FlexibleColumns

--- a/src/main/kotlin/org/vaccineimpact/api/models/BurdenEstimate.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/BurdenEstimate.kt
@@ -8,9 +8,9 @@ import java.math.BigDecimal
 data class AggregatedBurdenEstimate
 @ConstructorProperties("year", "age", "value")
 constructor(
-        val year: Short,
+        val x: Short,
         val age: Short,
-        val value: Float
+        val y: Float
 )
 
 interface BurdenEstimateRow

--- a/src/main/kotlin/org/vaccineimpact/api/models/BurdenEstimate.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/BurdenEstimate.kt
@@ -4,6 +4,12 @@ import org.vaccineimpact.api.models.helpers.FlexibleColumns
 import org.vaccineimpact.api.models.helpers.FlexibleProperty
 import java.math.BigDecimal
 
+data class AggregatedBurdenEstimate(
+        val year: Int,
+        val age: Int,
+        val value: Float
+)
+
 interface BurdenEstimateRow
 
 @FlexibleColumns

--- a/src/main/kotlin/org/vaccineimpact/api/models/ChartData.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/ChartData.kt
@@ -2,35 +2,16 @@ package org.vaccineimpact.api.models
 
 import java.beans.ConstructorProperties
 
-data class DataPoint
-constructor(
-        val x: Short,
-        val y: Float
-)
+data class BurdenEstimateDataSeries(val burdenEstimateGrouping: BurdenEstimateGrouping,
+                                    val data: Map<Short, List<BurdenEstimateDataPoint>>)
 
-interface ChartSerializable
-{
-    fun toDataPoint(): DataPoint
-}
-
-data class DisAggregatedBurdenEstimate
+data class BurdenEstimateDataPoint
 @ConstructorProperties("year", "age", "value", "groupBy")
 constructor(
         val year: Short,
         val age: Short,
-        val value: Float,
-        val groupBy: BurdenEstimateGrouping
-) : ChartSerializable
-{
-    override fun toDataPoint(): DataPoint = if (groupBy == BurdenEstimateGrouping.AGE)
-    {
-        DataPoint(this.year, this.value)
-    }
-    else
-    {
-        DataPoint(this.age, this.value)
-    }
-}
+        val value: Float
+)
 
 enum class BurdenEstimateGrouping
 {

--- a/src/main/kotlin/org/vaccineimpact/api/models/ChartData.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/ChartData.kt
@@ -1,0 +1,38 @@
+package org.vaccineimpact.api.models
+
+import java.beans.ConstructorProperties
+
+data class DataPoint
+constructor(
+        val x: Short,
+        val y: Float
+)
+
+interface ChartSerializable
+{
+    fun toDataPoint(): DataPoint
+}
+
+data class DisAggregatedBurdenEstimate
+@ConstructorProperties("year", "age", "value", "groupBy")
+constructor(
+        val year: Short,
+        val age: Short,
+        val value: Float,
+        val groupBy: BurdenEstimateGrouping
+) : ChartSerializable
+{
+    override fun toDataPoint(): DataPoint = if (groupBy == BurdenEstimateGrouping.AGE)
+    {
+        DataPoint(this.year, this.value)
+    }
+    else
+    {
+        DataPoint(this.age, this.value)
+    }
+}
+
+enum class BurdenEstimateGrouping
+{
+    AGE, YEAR
+}


### PR DESCRIPTION
`DisAggregatedBurdenEstimate` is the model used internally, `DataPoint` is the model we map to on serialization to return data in a format that can be used by "react-vis".