### PR TITLE
Added HIGH, LOW and BESTCASE to GAVISupport enum

### DIFF
--- a/src/main/kotlin/org/vaccineimpact/api/models/GAVISupportLevel.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/GAVISupportLevel.kt
@@ -5,6 +5,9 @@ enum class GAVISupportLevel
     NONE,
     WITHOUT,
     WITH,
+    HIGH,
+    LOW,
+    BESTCASE,
 
     // Only used in legacy data
     HOLD2010,


### PR DESCRIPTION
There's a GAVISupportLevel table in the database. Do we need to remember to migrate or repopulate the db to include new values?