### PR TITLE
move expectation related models into own subdirectory

### DIFF
--- a/src/main/kotlin/org/vaccineimpact/api/models/expectations/AppliedExpectation.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/expectations/AppliedExpectation.kt
@@ -1,4 +1,4 @@
-package org.vaccineimpact.api.models
+package org.vaccineimpact.api.models.expectations
 
 interface AppliedExpectation
 {

--- a/src/main/kotlin/org/vaccineimpact/api/models/expectations/BurdenEstimateRowLookup.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/expectations/BurdenEstimateRowLookup.kt
@@ -1,4 +1,4 @@
-package org.vaccineimpact.api.models
+package org.vaccineimpact.api.models.expectations
 
 typealias YearLookup = HashMap<Short, Boolean>
 typealias Year = Map.Entry<Short, Boolean>

--- a/src/main/kotlin/org/vaccineimpact/api/models/expectations/CountryOutcomeExpectations.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/expectations/CountryOutcomeExpectations.kt
@@ -1,5 +1,6 @@
-package org.vaccineimpact.api.models
+package org.vaccineimpact.api.models.expectations
 
+import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.models.helpers.FlexibleProperty
 import kotlin.coroutines.experimental.buildSequence
 

--- a/src/main/kotlin/org/vaccineimpact/api/models/expectations/ExpectationMapping.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/expectations/ExpectationMapping.kt
@@ -1,4 +1,4 @@
-package org.vaccineimpact.api.models
+package org.vaccineimpact.api.models.expectations
 
 data class ExpectationMapping(
         override val expectation: CountryOutcomeExpectations,

--- a/src/main/kotlin/org/vaccineimpact/api/models/expectations/Expectations.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/expectations/Expectations.kt
@@ -1,4 +1,6 @@
-package org.vaccineimpact.api.models
+package org.vaccineimpact.api.models.expectations
+
+import org.vaccineimpact.api.models.Outcome
 
 interface Expectations
 {

--- a/src/main/kotlin/org/vaccineimpact/api/models/expectations/OutcomeExpectations.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/expectations/OutcomeExpectations.kt
@@ -1,4 +1,6 @@
-package org.vaccineimpact.api.models
+package org.vaccineimpact.api.models.expectations
+
+import org.vaccineimpact.api.models.Outcome
 
 data class OutcomeExpectations(override val id: Int,
                                override val description: String,

--- a/src/main/kotlin/org/vaccineimpact/api/models/expectations/TouchstoneModelExpectations.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/expectations/TouchstoneModelExpectations.kt
@@ -1,4 +1,4 @@
-package org.vaccineimpact.api.models
+package org.vaccineimpact.api.models.expectations
 
 import java.beans.ConstructorProperties
 

--- a/src/main/kotlin/org/vaccineimpact/api/models/responsibilities/ResponsibilityDetails.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/responsibilities/ResponsibilityDetails.kt
@@ -1,6 +1,6 @@
 package org.vaccineimpact.api.models.responsibilities
 
-import org.vaccineimpact.api.models.CountryOutcomeExpectations
+import org.vaccineimpact.api.models.expectations.CountryOutcomeExpectations
 import org.vaccineimpact.api.models.TouchstoneVersion
 
 data class ResponsibilityDetails(

--- a/src/main/kotlin/org/vaccineimpact/api/models/responsibilities/ResponsibilitySetWithExpectations.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/responsibilities/ResponsibilitySetWithExpectations.kt
@@ -1,6 +1,6 @@
 package org.vaccineimpact.api.models.responsibilities
 
-import org.vaccineimpact.api.models.ExpectationMapping
+import org.vaccineimpact.api.models.expectations.ExpectationMapping
 
 data class ResponsibilitySetWithExpectations(
         val modellingGroupId: String,


### PR DESCRIPTION
So they're easier to quickly find.