### PR TITLE
VIMC-4767 Add comments to responsibility sets

### DIFF
--- a/src/main/kotlin/org/vaccineimpact/api/models/responsibilities/ResponsibilitySet.kt
+++ b/src/main/kotlin/org/vaccineimpact/api/models/responsibilities/ResponsibilitySet.kt
@@ -13,5 +13,6 @@ data class ResponsibilitySet(
 data class ResponsibilitySetWithComments(
         val touchstoneVersion: String,
         val modellingGroupId: String,
+        val comment: ResponsibilityComment?,
         val responsibilities: List<ResponsibilityWithComment>
 )


### PR DESCRIPTION
Add optional `comment` field to recently-added `ResponsibilitySetWithComments` class. This is the class returned by the admin-only touchstone version comments endpoint, which the front-end combines with the response from the long-standing touchstone version responsibilities endpoint.

This field re-uses the `ResponsibilityComment` class. Apart from avoiding redundancy this also makes it easier for the comment-editing UI to be agnostic over whether a responsibility or responsibility set is being annotated. I haven't renamed it to `Comment` as it's currently only used in the context of responsibilities, but this would be easy to change, either now or in the future.